### PR TITLE
test-max-range

### DIFF
--- a/main.js
+++ b/main.js
@@ -48,17 +48,17 @@ function getagerange(score) {
   switch (true) {
   case  score <= 298:
     return "Your reaction age is less than 18 years old!";
-  case score >= 299 && score < 387:
+  case score >= 299 && score <= 387:
     return "Your reaction age is: \r\n\ 20 to 30 years old!";
-  case score >= 388 && score < 475:
+  case score >= 388 && score <= 475:
     return "Your reaction age is: \r\n\ 30 to 40 years old!";
-  case score >= 476 && score < 574:
+  case score >= 476 && score <= 574:
     return "Your reaction age is: \r\n\ 40 to 50 years old!";
-  case score >= 575 && score < 684:
+  case score >= 575 && score <= 684:
     return "Your reaction age is: \r\n\ 50 to 60 years old!";
-  case score > 685 && score < 806:
+  case score > 685 && score <= 806:
     return "Your reaction age is: \r\n\ 60 to 70 years old!";
-  case score >= 807 && score < 940:
+  case score >= 807 && score <= 940:
     return "Your reaction age is: \r\n\ 70 to 80 years old!"
   case score >= 941:
     return "Your reaction age is: \r\n\ 80 to 90 years old!"

--- a/main.test.js
+++ b/main.test.js
@@ -18,5 +18,11 @@ describe('Testing the lower breakpoint', () => {
       expect(getagerange(299)).toBe('Your reaction age is: \r\n\ 20 to 30 years old!');
       expect(getagerange(300)).not.toBe('Your reaction age is: \r\n\ 80 to 90 years old!');
    });
+
+   it('That function getagerange works as expected on max of first range', () => {
+      expect(getagerange(387)).toBe('Your reaction age is: \r\n\ 20 to 30 years old!');
+      expect(getagerange(388)).toBe('Your reaction age is: \r\n\ 30 to 40 years old!');
+      expect(getagerange(388)).not.toBe('Your reaction age is: \r\n\ 80 to 90 years old!');
+   });
    
 })


### PR DESCRIPTION
 PASS  ./main.test.js
  √ that Jest is working (1 ms)
  Testing the lower breakpoint
    √ That function getagerange works as expected for score <298 (1 ms)
    √ That function getagerange works as expected on 298 and surrounding values (1 ms)
    √ That function getagerange works as expected on max of first range (1 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.656 s, estimated 1 s
Ran all test suites.